### PR TITLE
Enable sensible redis options

### DIFF
--- a/lib/utils/redis-client.js
+++ b/lib/utils/redis-client.js
@@ -1,12 +1,19 @@
 const Redis = require('ioredis');
 const config = require('../../config');
 
+const REDIS_OPTIONS = {
+	maxRetriesPerRequest: 1,
+	showFriendlyErrorStack: true,
+	reconnectOnError: false,
+	retryStrategy: false
+};
+
 let redis;
 
 exports.instance = () => {
 	if (redis) { return redis; }
 
-	redis = new Redis(config.redisUrl);
+	redis = new Redis(config.redisUrl, REDIS_OPTIONS);
 	return redis;
 };
 


### PR DESCRIPTION
Enable sensible `ioredis` options - fail quick, whilst minimising effects on host apps

By default, `ioredis` would keep trying to reconnect - which is nice, but we don't want it to do that as it would effect the host apps.  These options are as follows:

- `maxRetriesPerRequest`: set to `1`, it would try to read/write once, then aborts if unsuccessful
- `showFriendlyErrorStack`: set to `true`, if an error occurs, by default, the errors are scoped to the `ioredis` packaged.  Setting it to `true` scopes the errors to our code instead
- `reconnectOnError`: set to `false`, if an error occurs, do not try to reconnect, as this might effect the host app
- `retryStrategy`: set to `false`, if an issue occurs, we will not retry the request, again, being on the safe side

List of available options: https://github.com/luin/ioredis/blob/master/API.md#new-redisport-host-options 🦔