### PR TITLE
Add event namespacing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,6 +42,8 @@ module.exports = {
 		"no-return-assign": "off",
 		"no-use-before-define": "off",
 		"no-underscore-dangle": "off",
+		"object-curly-newline": "off",
+		"arrow-body-style": "off",
 		"prefer-object-spread/prefer-object-spread": 2,
 		"object-curly-spacing": [
 			"error",

--- a/config.js
+++ b/config.js
@@ -1,7 +1,11 @@
 const config = {
 	redisUrl: process.env.STETHOSCOPE_REDIS_URL,
 	redisReconnectionDelay: 0,
-	keyTtl: 86400
+	keyTtl: 86400,
+
+	// event keys
+	eventKeyDelimiter: ':',
+	ageEventKeyPrefix: 'AGE',
 };
 
 if (process.env.NODE_ENV !== 'production') {

--- a/lib/loggers/age.js
+++ b/lib/loggers/age.js
@@ -3,9 +3,10 @@ const redisClient = require('../utils/redis-client');
 const { eventKey } = require('../utils/event-key');
 const errorLogger = require('../utils/error-logger');
 const { keyTtl } = require('../../config');
+const { ageEventKeyPrefix: prefix } = require('../../config');
 
-module.exports.startEvent = async ({ event, identifier, expire = keyTtl }) => {
-	const key = eventKey(event, identifier);
+exports.startEvent = async ({ event, identifier, expire = keyTtl }) => {
+	const key = eventKey({ prefix, event, identifier });
 	const redis = redisClient.instance();
 
 	try {
@@ -18,9 +19,8 @@ module.exports.startEvent = async ({ event, identifier, expire = keyTtl }) => {
 	}
 };
 
-
-module.exports.endEvent = async ({ event, identifier }) => {
-	const key = eventKey(event, identifier);
+exports.endEvent = async ({ event, identifier }) => {
+	const key = eventKey({ prefix, event, identifier });
 	const redis = redisClient.instance();
 
 	try {

--- a/lib/metrics/age.js
+++ b/lib/metrics/age.js
@@ -2,9 +2,11 @@ const logger = require('../utils/logger');
 const { eventKey } = require('../utils/event-key');
 const redisClient = require('../utils/redis-client');
 const errorLogger = require('../utils/error-logger');
+const { ageEventKeyPrefix: prefix } = require('../../config');
+const { getAllEvents } = require('../utils/events');
 
 exports.eventAge = async ({ event, identifier }) => {
-	const key = eventKey(event, identifier);
+	const key = eventKey({ prefix, event, identifier });
 	const redis = redisClient.instance();
 
 	try {
@@ -17,7 +19,7 @@ exports.eventAge = async ({ event, identifier }) => {
 };
 
 exports.eventsAge = async ({ event, operation }) => {
-	const key = eventKey(event);
+	const key = eventKey({ prefix, event });
 
 	try {
 		if (!validOperations[operation]) { return logger.error(`Attempted to use invalid operation: ${operation}.  Valid operations are: ${Object.keys(validOperations)}`); }
@@ -30,20 +32,16 @@ exports.eventsAge = async ({ event, operation }) => {
 };
 
 exports.orderedEvents = async ({ limit } = {}) => {
+	const key = eventKey({ prefix });
+
 	try {
-		const events = (await getAllEvents()).map(decorateWithAge).sort(compareByAge).slice(0, limit);
+		const events = (await getAllEvents(`${key}*`)).map(decorateWithAge).sort(compareByAge).slice(0, limit);
 		return events.length ? events : undefined;
 	} catch (err) {
 		return errorLogger.logUnexpectedError(err);
 	}
 };
 
-const getAllEvents = async (pattern = '*') => {
-	const redis = redisClient.instance();
-
-	const keys = await redis.keys(pattern);
-	return Promise.all(keys.map(key => redis.hgetall(key)));
-};
 const decorateWithAge = event => ({ ...event, age: _age(event) });
 const compareByAge = (event1, event2) => event2.age - event1.age;
 

--- a/lib/utils/event-key.js
+++ b/lib/utils/event-key.js
@@ -1,1 +1,7 @@
-exports.eventKey = (event, identifier) => (event && identifier) ? `${event}:${identifier}` : event;
+const { eventKeyDelimiter } = require('../../config');
+
+exports.eventKey = ({ prefix, event, identifier }) => {
+	return [prefix, event, identifier].filter(identity).join(eventKeyDelimiter);
+};
+
+const identity = value => value;

--- a/lib/utils/events.js
+++ b/lib/utils/events.js
@@ -1,0 +1,8 @@
+const redisClient = require('../utils/redis-client');
+
+exports.getAllEvents = async (keyPattern) => {
+	const redis = redisClient.instance();
+
+	const keys = await redis.keys(keyPattern);
+	return Promise.all(keys.map(key => redis.hgetall(key)));
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/email-stethoscope",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Collecting performance and health data from various places throughout the email platform",
   "main": "index.js",
   "directories": {

--- a/test/lib/loggers/age.test.js
+++ b/test/lib/loggers/age.test.js
@@ -7,6 +7,7 @@ const redisClient = require('../../../lib/utils/redis-client');
 const { startEvent, endEvent } = require('../../../lib/loggers/age');
 const { eventKey } = require('../../../lib/utils/event-key');
 const errorLogger = require('../../../lib/utils/error-logger');
+const { ageEventKeyPrefix: prefix } = require('../../../config');
 
 describe('Loggers > Events Age', () => {
 	beforeEach(() => this.clock = sinon.useFakeTimers(Date.now()));
@@ -24,7 +25,7 @@ describe('Loggers > Events Age', () => {
 				const event = 'PROCESSING_LIST';
 				const identifier = '7da32a14-a9f1-4582-81eb-e4216e0d9a51';
 				const expire = 1000;
-				const expectedKey = eventKey(event, identifier);
+				const expectedKey = eventKey({ prefix, event, identifier });
 
 				const redisExistsSpy = sinon.spy(Redis.prototype, 'exists');
 				const redisHmsetSpy = sinon.spy(Redis.prototype, 'hmset');
@@ -40,7 +41,7 @@ describe('Loggers > Events Age', () => {
 			it('defaults expiration to "86400" if not specified', async () => {
 				const event = 'PROCESSING_LIST';
 				const identifier = '7da32a14-a9f1-4582-81eb-e4216e0d9a51';
-				const expectedKey = eventKey(event, identifier);
+				const expectedKey = eventKey({ prefix, event, identifier });
 
 				const redisExpireSpy = sinon.spy(Redis.prototype, 'expire');
 
@@ -54,7 +55,7 @@ describe('Loggers > Events Age', () => {
 			it('logs an error', async () => {
 				const event = 'PROCESSING_LIST';
 				const identifier = '7da32a14-a9f1-4582-81eb-e4216e0d9a51';
-				const expectedKey = eventKey(event, identifier);
+				const expectedKey = eventKey({ prefix, event, identifier });
 
 				sinon.stub(Redis.prototype, 'exists').returns(1);
 				const loggerSpy = sinon.stub(logger, 'warn');
@@ -69,7 +70,7 @@ describe('Loggers > Events Age', () => {
 			it('logs an error', async () => {
 				const event = 'PROCESSING_LIST';
 				const identifier = '7da32a14-a9f1-4582-81eb-e4216e0d9a51';
-				const expectedKey = eventKey(event, identifier);
+				const expectedKey = eventKey({ prefix, event, identifier });
 				const expectedError = new Error('Connection is closed');
 
 				sinon.stub(Redis.prototype, 'exists').throws(expectedError);
@@ -87,7 +88,7 @@ describe('Loggers > Events Age', () => {
 			it('ends the event with the current date', async () => {
 				const event = 'PROCESSING_LIST';
 				const identifier = '7da32a14-a9f1-4582-81eb-e4216e0d9a51';
-				const expectedKey = eventKey(event, identifier);
+				const expectedKey = eventKey({ prefix, event, identifier });
 
 				const redisHgetallSpy = sinon.spy(Redis.prototype, 'hgetall');
 				const redisHmsetSpy = sinon.spy(Redis.prototype, 'hmset');
@@ -104,7 +105,7 @@ describe('Loggers > Events Age', () => {
 			it('logs an error', async () => {
 				const event = 'PROCESSING_LIST';
 				const identifier = '7da32a14-a9f1-4582-81eb-e4216e0d9a51';
-				const expectedKey = eventKey(event, identifier);
+				const expectedKey = eventKey({ prefix, event, identifier });
 
 				sinon.stub(Redis.prototype, 'hgetall').returns({});
 				const loggerStub = sinon.stub(logger, 'warn');
@@ -119,7 +120,7 @@ describe('Loggers > Events Age', () => {
 			it('logs an error', async () => {
 				const event = 'PROCESSING_LIST';
 				const identifier = '7da32a14-a9f1-4582-81eb-e4216e0d9a51';
-				const expectedKey = eventKey(event, identifier);
+				const expectedKey = eventKey({ prefix, event, identifier });
 
 				sinon.stub(Redis.prototype, 'hgetall').returns({ startDate: Date.now(), endDate: Date.now() });
 				const loggerStub = sinon.stub(logger, 'warn');
@@ -134,7 +135,7 @@ describe('Loggers > Events Age', () => {
 			it('logs an error', async () => {
 				const event = 'PROCESSING_LIST';
 				const identifier = '7da32a14-a9f1-4582-81eb-e4216e0d9a51';
-				const expectedKey = eventKey(event, identifier);
+				const expectedKey = eventKey({ prefix, event, identifier });
 				const expectedError = new Error('Connection is closed');
 
 				sinon.stub(Redis.prototype, 'hgetall').throws(expectedError);

--- a/test/lib/metrics/age.test.js
+++ b/test/lib/metrics/age.test.js
@@ -8,6 +8,7 @@ const { eventAge, eventsAge, orderedEvents } = require('../../../lib/metrics/age
 const errorLogger = require('../../../lib/utils/error-logger');
 const { eventKey } = require('../../../lib/utils/event-key');
 const redisClient = require('../../../lib/utils/redis-client');
+const { ageEventKeyPrefix: prefix } = require('../../../config');
 
 describe('Metrics > Events Age', () => {
 	beforeEach(() => this.clock = sinon.useFakeTimers(Date.now()));
@@ -47,7 +48,7 @@ describe('Metrics > Events Age', () => {
 			it('logs an error', async () => {
 				const event = 'PROCESSING_LIST';
 				const identifier = '7da32a14-a9f1-4582-81eb-e4216e0d9a51';
-				const expectedEventKey = eventKey(event, identifier);
+				const expectedEventKey = eventKey({ prefix, event, identifier });
 				const expectedError = new Error('Something went wrong');
 
 				const errorLoggerStub = sinon.stub(errorLogger, 'logUnexpectedError');
@@ -149,7 +150,7 @@ describe('Metrics > Events Age', () => {
 		describe('with unexpected error', () => {
 			it('logs the error', async () => {
 				const event = 'PROCESSING_LIST';
-				const expectedEventKey = eventKey(event);
+				const expectedEventKey = eventKey({ prefix, event });
 				const expectedError = new Error('Something went wrong');
 
 				const errorLoggerStub = sinon.stub(errorLogger, 'logUnexpectedError');

--- a/test/lib/utils/error-logger.test.js
+++ b/test/lib/utils/error-logger.test.js
@@ -10,7 +10,9 @@ describe('Utils > Error Logger', () => {
 
 	describe('.logUnexpectedError', () => {
 		it('logs the error', () => {
-			const expectedKey = eventKey('PROCESSING_LIST', '7da32a14-a9f1-4582-81eb-e4216e0d9a51');
+			const event = 'PROCESSING_LIST';
+			const identifier = '7da32a14-a9f1-4582-81eb-e4216e0d9a51';
+			const expectedKey = eventKey({ event, identifier });
 			const expectedError = new Error('Something went wrong');
 			const expectedLoggedError = `Unexpected error occured: '${expectedError.message}' for key: ${expectedKey}`;
 			const loggerStub = sinon.stub(logger, 'error');

--- a/test/lib/utils/event-key.test.js
+++ b/test/lib/utils/event-key.test.js
@@ -1,28 +1,40 @@
 const { expect } = require('chai');
 
 const { eventKey } = require('../../../lib/utils/event-key');
+const { ageEventKeyPrefix: prefix, eventKeyDelimiter } = require('../../../config');
 
 describe('Utils > Event Key', () => {
 	describe('.eventKey', () => {
-		beforeEach(() => {
-			this.event = 'PROCESSING_LIST';
-			this.identifier = '7da32a14-a9f1-4582-81eb-e4216e0d9a51';
-		});
-
-		describe('with no identifier', () => {
+		describe('with event', () => {
 			it('returns the event as the key', () => {
-				this.identifier = undefined;
-				const expectedKey = `${this.event}`;
+				const event = 'PROCESSING_LIST';
+				const identifier = undefined;
 
-				expect(eventKey(this.event, this.identifier)).to.equal(expectedKey);
+				const expectedKey = `${event}`;
+
+				expect(eventKey({ event, identifier })).to.equal(expectedKey);
 			});
 		});
 
 		describe('with event and identifier', () => {
 			it('returns the event and identifier as the key', () => {
-				const expectedKey = `${this.event}:${this.identifier}`;
+				const event = 'PROCESSING_LIST';
+				const identifier = '7da32a14-a9f1-4582-81eb-e4216e0d9a51';
 
-				expect(eventKey(this.event, this.identifier)).to.equal(expectedKey);
+				const expectedKey = `${event}${eventKeyDelimiter}${identifier}`;
+
+				expect(eventKey({ event, identifier })).to.equal(expectedKey);
+			});
+		});
+
+		describe('with prefix, event and identifier', () => {
+			it('returns the prefix, event and identifier as the key', () => {
+				const event = 'PROCESSING_LIST';
+				const identifier = '7da32a14-a9f1-4582-81eb-e4216e0d9a51';
+
+				const expectedKey = `${prefix}${eventKeyDelimiter}${event}${eventKeyDelimiter}${identifier}`;
+
+				expect(eventKey({ prefix, event, identifier })).to.equal(expectedKey);
 			});
 		});
 	});

--- a/test/lib/utils/events.test.js
+++ b/test/lib/utils/events.test.js
@@ -1,0 +1,46 @@
+const { expect } = require('chai');
+
+const { startEvent, endEvent } = require('../../../lib/loggers/age');
+const redisClient = require('../../../lib/utils/redis-client');
+const { getAllEvents } = require('../../../lib/utils/events');
+
+describe('Utils > Events', () => {
+	afterEach(async () => {
+		await redisClient.instance().flushall();
+		redisClient.disconnect();
+	});
+
+	describe('.getAllEvents', () => {
+		describe('with existing event', () => {
+			describe('with no key pattern', () => {
+				it('returns empty array', async () => {
+					const event = 'PROCESSING_LIST';
+					const identifier = '7da32a14-a9f1-4582-81eb-e4216e0d9a51';
+
+					await startEvent({ event, identifier });
+					await endEvent({ event, identifier });
+
+					expect(await getAllEvents()).to.be.empty;
+				});
+			});
+
+			describe('with key pattern', () => {
+				it('returns matched events', async () => {
+					const event = 'PROCESSING_LIST';
+					const identifier = '7da32a14-a9f1-4582-81eb-e4216e0d9a51';
+
+					await startEvent({ event, identifier });
+					await endEvent({ event, identifier });
+
+					expect(await getAllEvents(`*${event}*`)).to.have.lengthOf(1);
+				});
+			});
+		});
+
+		describe('without existing event', () => {
+			it('returns empty array', async () => {
+				expect(await getAllEvents('*')).to.be.empty;
+			});
+		});
+	});
+});


### PR DESCRIPTION
This adds event name-spacing, eg: `AGE`, `ERROR`, to allow us to efficiently query the db, to get error events, for example.

This enables us to track errors and efficiently query for them

eg:

```
AGE:PROCESSING_LIST:7da32a14-a9f1-4582-81eb-e4216e0d9a51
ERROR:PROCESSING_LIST:7da32a14-a9f1-4582-81eb-e4216e0d9a51
```