### PR TITLE
Quick Fix: Don't buffer mongoose commands

### DIFF
--- a/lib/loggers/age.js
+++ b/lib/loggers/age.js
@@ -14,6 +14,7 @@ exports.startEvent = async ({ event, identifier }) => {
 exports.endEvent = async ({ event, identifier }) => {
 	try {
 		const existingEvent = await AgeEvent.findOne({ event, identifier });
+		if (!existingEvent) { return logger.warn(`Attempted to end an event that has not started. ${{ event, identifier }}`); }
 		if (existingEvent.endedAt) { return logger.warn(`Attempted to end an event that has already ended. ${{ event, identifier }}`); }
 
 		return await existingEvent.set({ endedAt: Date.now() }).save();

--- a/lib/loggers/age.js
+++ b/lib/loggers/age.js
@@ -1,11 +1,8 @@
 const logger = require('../utils/logger');
 const errorLogger = require('../utils/error-logger');
 const { AgeEvent } = require('../db/models/age-event');
-const { isDbReady } = require('../utils/db');
 
 exports.startEvent = async ({ event, identifier }) => {
-	if (!isDbReady()) { return errorLogger.logDbNotReadyError(); }
-
 	try {
 		if (await AgeEvent.findOne({ event, identifier })) { return logger.warn(`Attempted to start an event that has already been started. ${{ event, identifier }}`); }
 		return await AgeEvent.create({ event, identifier, createdAt: Date.now() });
@@ -15,8 +12,6 @@ exports.startEvent = async ({ event, identifier }) => {
 };
 
 exports.endEvent = async ({ event, identifier }) => {
-	if (!isDbReady()) { return errorLogger.logDbNotReadyError(); }
-
 	try {
 		const existingEvent = await AgeEvent.findOne({ event, identifier });
 		if (existingEvent.endedAt) { return logger.warn(`Attempted to end an event that has already ended. ${{ event, identifier }}`); }

--- a/lib/metrics/age.js
+++ b/lib/metrics/age.js
@@ -1,12 +1,8 @@
 const logger = require('../utils/logger');
-const { logDbNotReadyError } = require('../utils/error-logger');
 const { AgeEvent } = require('../db/models/age-event');
-const { isDbReady } = require('../utils/db');
 const errorLogger = require('../utils/error-logger');
 
 exports.eventAge = async ({ event, identifier }) => {
-	if (!isDbReady()) { return logDbNotReadyError(); }
-
 	try {
 		const existingEvent = await AgeEvent.findOne({ event, identifier });
 
@@ -17,8 +13,6 @@ exports.eventAge = async ({ event, identifier }) => {
 };
 
 exports.eventsAge = async ({ event, operation }) => {
-	if (!isDbReady()) { return logDbNotReadyError(); }
-
 	try {
 		if (!validOperations[operation]) { return logger.error(`Attempted to use invalid operation: ${operation}.  Valid operations are: ${Object.keys(validOperations)}`); }
 
@@ -30,8 +24,6 @@ exports.eventsAge = async ({ event, operation }) => {
 };
 
 exports.orderedEvents = async ({ limit } = {}) => {
-	if (!isDbReady()) { return logDbNotReadyError(); }
-
 	try {
 		const events = (await AgeEvent.find()).sort(compareByAge).slice(0, limit);
 		return events.length ? events : undefined;

--- a/lib/utils/db.js
+++ b/lib/utils/db.js
@@ -4,18 +4,19 @@ const { dbURI } = require('../../config');
 
 const dbInstance = new Mongoose();
 
-exports.isDbReady = () => dbInstance.connection.readyState;
 exports.dbInstance = dbInstance;
 
 exports.connect = async () => {
-	if (exports.isDbReady()) { return; }
+	if (dbInstance.connection.readyState) { return; }
 
 	await dbInstance.connect(dbURI, {
 		useNewUrlParser: true,
 		useCreateIndex: true,
 		autoReconnect: true,
 		reconnectInterval: 1000,
-		reconnectTries: 100
+		reconnectTries: 100,
+		bufferCommands: false,
+		bufferMaxEntries: 0
 	});
 };
 

--- a/lib/utils/error-logger.js
+++ b/lib/utils/error-logger.js
@@ -1,4 +1,3 @@
 const logger = require('./logger');
 
 exports.logUnexpectedError = err => logger.error(`Unexpected error occurred: '${err.message}'`);
-exports.logDbNotReadyError = () => logger.warn('Stethoscope DB not ready.  Please check connection');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/email-stethoscope",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/email-stethoscope",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Collecting performance and health data from various places throughout the email platform",
   "main": "index.js",
   "directories": {

--- a/test/lib/loggers/age.test.js
+++ b/test/lib/loggers/age.test.js
@@ -12,134 +12,104 @@ describe('Loggers > Events Age', () => {
 	afterEach(() => sinon.restore());
 
 	describe('.startEvent', () => {
-		describe('with db connection not ready', () => {
-			before(async () => { await db.disconnect(); });
+		beforeEach(async () => { await db.connect(); });
 
-			it('logs a "db not ready" warning', async () => {
-				const errorLoggerSpy = sinon.spy(errorLogger, 'logDbNotReadyError');
+		afterEach(async () => {
+			await AgeEvent.deleteMany();
+			await db.disconnect();
+		});
 
+		describe('with new event', () => {
+			it('starts the new event with current date', async () => {
 				const { event, identifier } = ageEventFixture;
+
+				const findOneSpy = sinon.stub(AgeEvent, 'findOne');
+				const createSpy = sinon.stub(AgeEvent, 'create');
+
 				await startEvent({ event, identifier });
 
-				expect(errorLoggerSpy.calledOnce).to.be.true;
+				expect(findOneSpy.calledWith({ event, identifier })).to.be.true;
+				expect(createSpy.calledWith({ event, identifier, createdAt: Date.now() })).to.be.true;
 			});
 		});
 
-		describe('with db connection ready', () => {
-			beforeEach(async () => { await db.connect(); });
+		describe('with existing event', () => {
+			it('logs an error', async () => {
+				const { event, identifier } = ageEventFixture;
 
-			afterEach(async () => {
-				await AgeEvent.deleteMany();
-				await db.disconnect();
+				await AgeEvent.create({ event, identifier, createdAt: Date.now() });
+				const loggerStub = sinon.stub(logger, 'warn');
+
+				await startEvent({ event, identifier });
+
+				expect(loggerStub.calledWith(`Attempted to start an event that has already been started. ${{ event, identifier }}`)).to.be.true;
 			});
+		});
 
-			describe('with new event', () => {
-				it('starts the new event with current date', async () => {
-					const { event, identifier } = ageEventFixture;
+		describe('with unexpected error', () => {
+			it('logs an error', async () => {
+				const { event, identifier } = ageEventFixture;
 
-					const findOneSpy = sinon.stub(AgeEvent, 'findOne');
-					const createSpy = sinon.stub(AgeEvent, 'create');
+				const expectedError = new Error('Connection is closed');
 
-					await startEvent({ event, identifier });
+				sinon.stub(AgeEvent, 'create').rejects(expectedError);
+				const errorLoggerSpy = sinon.spy(errorLogger, 'logUnexpectedError');
 
-					expect(findOneSpy.calledWith({ event, identifier })).to.be.true;
-					expect(createSpy.calledWith({ event, identifier, createdAt: Date.now() })).to.be.true;
-				});
-			});
+				await startEvent({ event, identifier });
 
-			describe('with existing event', () => {
-				it('logs an error', async () => {
-					const { event, identifier } = ageEventFixture;
-
-					await AgeEvent.create({ event, identifier, createdAt: Date.now() });
-					const loggerStub = sinon.stub(logger, 'warn');
-
-					await startEvent({ event, identifier });
-
-					expect(loggerStub.calledWith(`Attempted to start an event that has already been started. ${{ event, identifier }}`)).to.be.true;
-				});
-			});
-
-			describe('with unexpected error', () => {
-				it('logs an error', async () => {
-					const { event, identifier } = ageEventFixture;
-
-					const expectedError = new Error('Connection is closed');
-
-					sinon.stub(AgeEvent, 'create').rejects(expectedError);
-					const errorLoggerSpy = sinon.spy(errorLogger, 'logUnexpectedError');
-
-					await startEvent({ event, identifier });
-
-					expect(errorLoggerSpy.calledOnce).to.be.true;
-				});
+				expect(errorLoggerSpy.calledOnce).to.be.true;
 			});
 		});
 	});
 
 	describe('.endEvent', () => {
-		describe('with db connection not ready', () => {
-			before(async () => { await db.disconnect(); });
+		beforeEach(async () => { await db.connect(); });
 
-			it('logs a "db not ready" warning', async () => {
-				const errorLoggerSpy = sinon.spy(errorLogger, 'logDbNotReadyError');
+		afterEach(async () => {
+			await AgeEvent.deleteMany();
+			await db.disconnect();
+		});
 
+		describe('with a started event', () => {
+			it('ends the event with the current date', async () => {
 				const { event, identifier } = ageEventFixture;
-				await startEvent({ event, identifier });
 
-				expect(errorLoggerSpy.calledOnce).to.be.true;
+				await startEvent({ event, identifier });
+				await endEvent({ event, identifier });
+
+				expect((await AgeEvent.findOne({ event, identifier })).endedAt).to.equal(Date.now());
 			});
 		});
 
-		describe('with db connection ready', () => {
-			beforeEach(async () => { await db.connect(); });
+		describe('with event previously ended', () => {
+			it('logs an error', async () => {
+				const { event, identifier } = ageEventFixture;
 
-			afterEach(async () => {
-				await AgeEvent.deleteMany();
-				await db.disconnect();
+				await startEvent({ event, identifier });
+				await endEvent({ event, identifier });
+
+				const loggerStub = sinon.stub(logger, 'warn');
+
+				await endEvent({ event, identifier });
+
+				expect(loggerStub.calledWith(`Attempted to end an event that has already ended. ${{ event, identifier }}`)).to.be.true;
 			});
+		});
 
-			describe('with a started event', () => {
-				it('ends the event with the current date', async () => {
-					const { event, identifier } = ageEventFixture;
+		describe('with unexpected error', () => {
+			it('logs an error', async () => {
+				const { event, identifier } = ageEventFixture;
 
-					await startEvent({ event, identifier });
-					await endEvent({ event, identifier });
+				const expectedError = new Error('Connection is closed');
 
-					expect((await AgeEvent.findOne({ event, identifier })).endedAt).to.equal(Date.now());
-				});
-			});
+				await startEvent({ event, identifier });
 
-			describe('with event previously ended', () => {
-				it('logs an error', async () => {
-					const { event, identifier } = ageEventFixture;
+				sinon.stub(AgeEvent.prototype, 'save').rejects(expectedError);
+				const errorLoggerSpy = sinon.spy(errorLogger, 'logUnexpectedError');
 
-					await startEvent({ event, identifier });
-					await endEvent({ event, identifier });
+				await endEvent({ event, identifier });
 
-					const loggerStub = sinon.stub(logger, 'warn');
-
-					await endEvent({ event, identifier });
-
-					expect(loggerStub.calledWith(`Attempted to end an event that has already ended. ${{ event, identifier }}`)).to.be.true;
-				});
-			});
-
-			describe('with unexpected error', () => {
-				it('logs an error', async () => {
-					const { event, identifier } = ageEventFixture;
-
-					const expectedError = new Error('Connection is closed');
-
-					await startEvent({ event, identifier });
-
-					sinon.stub(AgeEvent.prototype, 'save').rejects(expectedError);
-					const errorLoggerSpy = sinon.spy(errorLogger, 'logUnexpectedError');
-
-					await endEvent({ event, identifier });
-
-					expect(errorLoggerSpy.calledOnce).to.be.true;
-				});
+				expect(errorLoggerSpy.calledOnce).to.be.true;
 			});
 		});
 	});

--- a/test/lib/loggers/age.test.js
+++ b/test/lib/loggers/age.test.js
@@ -81,6 +81,18 @@ describe('Loggers > Events Age', () => {
 			});
 		});
 
+		describe('without a started event', () => {
+			it('logs an error', async () => {
+				const { event, identifier } = ageEventFixture;
+
+				const loggerStub = sinon.stub(logger, 'warn');
+
+				await endEvent({ event, identifier });
+
+				expect(loggerStub.calledWith(`Attempted to end an event that has not started. ${{ event, identifier }}`)).to.be.true;
+			});
+		});
+
 		describe('with event previously ended', () => {
 			it('logs an error', async () => {
 				const { event, identifier } = ageEventFixture;

--- a/test/lib/metrics/age.test.js
+++ b/test/lib/metrics/age.test.js
@@ -13,285 +13,240 @@ describe('Metrics > Events Age', () => {
 	afterEach(() => sinon.restore());
 
 	describe('.eventAge', () => {
-		describe('with db connection not ready', () => {
-			before(async () => { await db.disconnect(); });
+		beforeEach(async () => { await db.connect(); });
 
-			it('logs a "db not ready" warning', async () => {
-				const errorLoggerSpy = sinon.spy(errorLogger, 'logDbNotReadyError');
+		afterEach(async () => {
+			await AgeEvent.deleteMany();
+			await db.disconnect();
+		});
 
+		describe('with existing event', () => {
+			it('returns the event age', async () => {
 				const { event, identifier } = ageEventFixture;
-				await startEvent({ event, identifier });
+				const expectedAge = 100;
 
-				expect(errorLoggerSpy.calledOnce).to.be.true;
+				await startEvent({ event, identifier });
+				this.clock.tick(expectedAge);
+				await endEvent({ event, identifier });
+
+				expect(await eventAge({ event, identifier })).to.equal(expectedAge);
 			});
 		});
 
-		describe('with db connection ready', () => {
-			beforeEach(async () => { await db.connect(); });
+		describe('without existing event', () => {
+			it('returns undefined', async () => {
+				const { event, identifier } = ageEventFixture;
 
-			afterEach(async () => {
-				await AgeEvent.deleteMany();
-				await db.disconnect();
+				expect(await eventAge({ event, identifier })).to.be.undefined;
 			});
+		});
 
-			describe('with existing event', () => {
-				it('returns the event age', async () => {
-					const { event, identifier } = ageEventFixture;
-					const expectedAge = 100;
+		describe('with unexpected error', () => {
+			it('logs an error', async () => {
+				const { event, identifier } = ageEventFixture;
 
-					await startEvent({ event, identifier });
-					this.clock.tick(expectedAge);
-					await endEvent({ event, identifier });
+				const expectedError = new Error('Something went wrong');
 
-					expect(await eventAge({ event, identifier })).to.equal(expectedAge);
-				});
-			});
+				const errorLoggerSpy = sinon.spy(errorLogger, 'logUnexpectedError');
+				sinon.stub(AgeEvent, 'findOne').rejects(expectedError);
 
-			describe('without existing event', () => {
-				it('returns undefined', async () => {
-					const { event, identifier } = ageEventFixture;
+				const age = await eventAge({ event, identifier });
 
-					expect(await eventAge({ event, identifier })).to.be.undefined;
-				});
-			});
-
-			describe('with unexpected error', () => {
-				it('logs an error', async () => {
-					const { event, identifier } = ageEventFixture;
-
-					const expectedError = new Error('Something went wrong');
-
-					const errorLoggerSpy = sinon.spy(errorLogger, 'logUnexpectedError');
-					sinon.stub(AgeEvent, 'findOne').rejects(expectedError);
-
-					const age = await eventAge({ event, identifier });
-
-					expect(errorLoggerSpy.calledOnce).to.be.true;
-					expect(age).to.be.undefined;
-				});
+				expect(errorLoggerSpy.calledOnce).to.be.true;
+				expect(age).to.be.undefined;
 			});
 		});
 	});
 
 	describe('.eventsAge', () => {
-		describe('with db connection not ready', () => {
-			before(async () => { await db.disconnect(); });
+		beforeEach(async () => { await db.connect(); });
 
-			it('logs a "db not ready" warning', async () => {
-				const errorLoggerSpy = sinon.spy(errorLogger, 'logDbNotReadyError');
+		afterEach(async () => {
+			await AgeEvent.deleteMany();
+			await db.disconnect();
+		});
 
-				const { event, identifier } = ageEventFixture;
-				await startEvent({ event, identifier });
+		describe('with invalid operation', () => {
+			it('logs an error', async () => {
+				const { event } = ageEventFixture;
 
-				expect(errorLoggerSpy.calledOnce).to.be.true;
+				const invalidOperation = 'somethingWrong';
+				const expectedLogMessage = `Attempted to use invalid operation: ${invalidOperation}`;
+				const loggerStub = sinon.stub(logger, 'error');
+
+				const age = await eventsAge({ event, operation: invalidOperation });
+
+				expect(loggerStub.calledWithMatch(expectedLogMessage)).to.be.true;
+				expect(age).to.be.undefined;
 			});
 		});
 
-		describe('with db connection ready', () => {
-			beforeEach(async () => { await db.connect(); });
-
-			afterEach(async () => {
-				await AgeEvent.deleteMany();
-				await db.disconnect();
-			});
-
-			describe('with invalid operation', () => {
-				it('logs an error', async () => {
-					const { event } = ageEventFixture;
-
-					const invalidOperation = 'somethingWrong';
-					const expectedLogMessage = `Attempted to use invalid operation: ${invalidOperation}`;
-					const loggerStub = sinon.stub(logger, 'error');
-
-					const age = await eventsAge({ event, operation: invalidOperation });
-
-					expect(loggerStub.calledWithMatch(expectedLogMessage)).to.be.true;
-					expect(age).to.be.undefined;
-				});
-			});
-
-			describe('with valid operation', () => {
-				describe('with existing event', () => {
-					describe('with "max" operation', () => {
-						it('returns max age', async () => {
-							const expectedMaxAge = 1000;
-							const { event } = ageEventFixture;
-
-							const identifier1 = '7da32a14-a9f1-4582-81eb-e4216e0d9a51';
-							const identifier2 = '9da32a14-a9f1-4582-81eb-e4216e0d9a52';
-
-							await startEvent({ event, identifier: identifier1 });
-							this.clock.tick(expectedMaxAge);
-							await endEvent({ event, identifier: identifier1 });
-
-							await startEvent({ event, identifier: identifier2 });
-							this.clock.tick(expectedMaxAge / 2);
-							await endEvent({ event, identifier: identifier2 });
-
-							expect(await eventsAge({ event, operation: 'max' })).to.equal(expectedMaxAge);
-						});
-					});
-
-					describe('with "min" operation', () => {
-						it('returns min age', async () => {
-							const expectedMinAge = 1000;
-							const { event } = ageEventFixture;
-
-							const identifier1 = '7da32a14-a9f1-4582-81eb-e4216e0d9a51';
-							const identifier2 = '9da32a14-a9f1-4582-81eb-e4216e0d9a52';
-
-							await startEvent({ event, identifier: identifier1 });
-							this.clock.tick(expectedMinAge);
-							await endEvent({ event, identifier: identifier1 });
-
-							await startEvent({ event, identifier: identifier2 });
-							this.clock.tick(expectedMinAge * 2);
-							await endEvent({ event, identifier: identifier2 });
-
-							expect(await eventsAge({ event, operation: 'min' })).to.equal(expectedMinAge);
-						});
-					});
-
-					describe('with "average" operation', () => {
-						it('returns average age', async () => {
-							const { event } = ageEventFixture;
-
-							const identifier1 = '7da32a14-a9f1-4582-81eb-e4216e0d9a51';
-							const identifier2 = '9da32a14-a9f1-4582-81eb-e4216e0d9a52';
-							const eventAge1 = 1000;
-							const eventAge2 = 2000;
-							const expectedAverage = (eventAge1 + eventAge2) / 2;
-
-							await startEvent({ event, identifier: identifier1 });
-							this.clock.tick(eventAge1);
-							await endEvent({ event, identifier: identifier1 });
-
-							await startEvent({ event, identifier: identifier2 });
-							this.clock.tick(eventAge2);
-							await endEvent({ event, identifier: identifier2 });
-
-							expect(await eventsAge({ event, operation: 'average' })).to.equal(expectedAverage);
-						});
-					});
-				});
-
-				describe('without existing event', () => {
-					it('returns undefined', async () => {
+		describe('with valid operation', () => {
+			describe('with existing event', () => {
+				describe('with "max" operation', () => {
+					it('returns max age', async () => {
+						const expectedMaxAge = 1000;
 						const { event } = ageEventFixture;
 
-						expect(await eventsAge({ event, operation: 'max' })).to.be.undefined;
+						const identifier1 = '7da32a14-a9f1-4582-81eb-e4216e0d9a51';
+						const identifier2 = '9da32a14-a9f1-4582-81eb-e4216e0d9a52';
+
+						await startEvent({ event, identifier: identifier1 });
+						this.clock.tick(expectedMaxAge);
+						await endEvent({ event, identifier: identifier1 });
+
+						await startEvent({ event, identifier: identifier2 });
+						this.clock.tick(expectedMaxAge / 2);
+						await endEvent({ event, identifier: identifier2 });
+
+						expect(await eventsAge({ event, operation: 'max' })).to.equal(expectedMaxAge);
+					});
+				});
+
+				describe('with "min" operation', () => {
+					it('returns min age', async () => {
+						const expectedMinAge = 1000;
+						const { event } = ageEventFixture;
+
+						const identifier1 = '7da32a14-a9f1-4582-81eb-e4216e0d9a51';
+						const identifier2 = '9da32a14-a9f1-4582-81eb-e4216e0d9a52';
+
+						await startEvent({ event, identifier: identifier1 });
+						this.clock.tick(expectedMinAge);
+						await endEvent({ event, identifier: identifier1 });
+
+						await startEvent({ event, identifier: identifier2 });
+						this.clock.tick(expectedMinAge * 2);
+						await endEvent({ event, identifier: identifier2 });
+
+						expect(await eventsAge({ event, operation: 'min' })).to.equal(expectedMinAge);
+					});
+				});
+
+				describe('with "average" operation', () => {
+					it('returns average age', async () => {
+						const { event } = ageEventFixture;
+
+						const identifier1 = '7da32a14-a9f1-4582-81eb-e4216e0d9a51';
+						const identifier2 = '9da32a14-a9f1-4582-81eb-e4216e0d9a52';
+						const eventAge1 = 1000;
+						const eventAge2 = 2000;
+						const expectedAverage = (eventAge1 + eventAge2) / 2;
+
+						await startEvent({ event, identifier: identifier1 });
+						this.clock.tick(eventAge1);
+						await endEvent({ event, identifier: identifier1 });
+
+						await startEvent({ event, identifier: identifier2 });
+						this.clock.tick(eventAge2);
+						await endEvent({ event, identifier: identifier2 });
+
+						expect(await eventsAge({ event, operation: 'average' })).to.equal(expectedAverage);
 					});
 				});
 			});
 
-			describe('with unexpected error', () => {
-				it('logs the error', async () => {
+			describe('without existing event', () => {
+				it('returns undefined', async () => {
 					const { event } = ageEventFixture;
 
-					const expectedError = new Error('Something went wrong');
-
-					sinon.stub(AgeEvent, 'find').rejects(expectedError);
-					const errorLoggerSpy = sinon.spy(errorLogger, 'logUnexpectedError');
-
-					await eventsAge({ event, operation: 'max' });
-
-					expect(errorLoggerSpy.calledOnce).to.be.true;
+					expect(await eventsAge({ event, operation: 'max' })).to.be.undefined;
 				});
+			});
+		});
+
+		describe('with unexpected error', () => {
+			it('logs the error', async () => {
+				const { event } = ageEventFixture;
+
+				const expectedError = new Error('Something went wrong');
+
+				sinon.stub(AgeEvent, 'find').rejects(expectedError);
+				const errorLoggerSpy = sinon.spy(errorLogger, 'logUnexpectedError');
+
+				await eventsAge({ event, operation: 'max' });
+
+				expect(errorLoggerSpy.calledOnce).to.be.true;
 			});
 		});
 	});
 
 	describe('.orderedEvents', () => {
-		describe('with db connection not ready', () => {
-			before(async () => { await db.disconnect(); });
+		beforeEach(async () => { await db.connect(); });
 
-			it('logs a "db not ready" warning', async () => {
-				const errorLoggerSpy = sinon.spy(errorLogger, 'logDbNotReadyError');
+		afterEach(async () => {
+			await AgeEvent.deleteMany();
+			await db.disconnect();
+		});
 
-				const { event, identifier } = ageEventFixture;
-				await startEvent({ event, identifier });
+		describe('without limit', () => {
+			it('returns all of events, sorted, with age', async () => {
+				const { event } = ageEventFixture;
 
-				expect(errorLoggerSpy.calledOnce).to.be.true;
+				const identifier1 = '7da32a14-a9f1-4582-81eb-e4216e0d9a51';
+				const identifier2 = '9da32a14-a9f1-4582-81eb-e4216e0d9a52';
+				const expectedAge = 120;
+
+				await startEvent({ event, identifier: identifier1 });
+				this.clock.tick(expectedAge);
+				await endEvent({ event, identifier: identifier1 });
+
+				await startEvent({ event, identifier: identifier2 });
+				this.clock.tick(expectedAge / 2);
+				await endEvent({ event, identifier: identifier2 });
+
+				const events = await orderedEvents();
+
+				expect(events.length).to.equal(2);
+				expect(events[0].age).to.equal(expectedAge);
+				expect(events[0].identifier).to.equal(identifier1);
+				expect(events[1].identifier).to.equal(identifier2);
 			});
 		});
 
-		describe('with db connection ready', () => {
-			beforeEach(async () => { await db.connect(); });
+		describe('with limit', () => {
+			it('returns the limited number of event, sorted, with age', async () => {
+				const { event } = ageEventFixture;
 
-			afterEach(async () => {
-				await AgeEvent.deleteMany();
-				await db.disconnect();
+				const identifier1 = '7da32a14-a9f1-4582-81eb-e4216e0d9a51';
+				const identifier2 = '9da32a14-a9f1-4582-81eb-e4216e0d9a52';
+				const expectedAge = 120;
+				const limit = 1;
+
+				await startEvent({ event, identifier: identifier1 });
+				this.clock.tick(expectedAge);
+				await endEvent({ event, identifier: identifier1 });
+
+				await startEvent({ event, identifier: identifier2 });
+				this.clock.tick(expectedAge / 2);
+				await endEvent({ event, identifier: identifier2 });
+				const events = await orderedEvents({ limit });
+
+				expect(events.length).to.equal(limit);
+				expect(events[0].age).to.equal(expectedAge);
+				expect(events[0].identifier).to.equal(identifier1);
 			});
+		});
 
-			describe('without limit', () => {
-				it('returns all of events, sorted, with age', async () => {
-					const { event } = ageEventFixture;
-
-					const identifier1 = '7da32a14-a9f1-4582-81eb-e4216e0d9a51';
-					const identifier2 = '9da32a14-a9f1-4582-81eb-e4216e0d9a52';
-					const expectedAge = 120;
-
-					await startEvent({ event, identifier: identifier1 });
-					this.clock.tick(expectedAge);
-					await endEvent({ event, identifier: identifier1 });
-
-					await startEvent({ event, identifier: identifier2 });
-					this.clock.tick(expectedAge / 2);
-					await endEvent({ event, identifier: identifier2 });
-
-					const events = await orderedEvents();
-
-					expect(events.length).to.equal(2);
-					expect(events[0].age).to.equal(expectedAge);
-					expect(events[0].identifier).to.equal(identifier1);
-					expect(events[1].identifier).to.equal(identifier2);
-				});
+		describe('with no events', () => {
+			it('returns undefined', async () => {
+				const events = await orderedEvents();
+				expect(events).to.be.undefined;
 			});
+		});
 
-			describe('with limit', () => {
-				it('returns the limited number of event, sorted, with age', async () => {
-					const { event } = ageEventFixture;
+		describe('with unexpected error', () => {
+			it('logs the error', async () => {
+				const { event } = ageEventFixture;
 
-					const identifier1 = '7da32a14-a9f1-4582-81eb-e4216e0d9a51';
-					const identifier2 = '9da32a14-a9f1-4582-81eb-e4216e0d9a52';
-					const expectedAge = 120;
-					const limit = 1;
+				const expectedError = new Error('Something went wrong');
 
-					await startEvent({ event, identifier: identifier1 });
-					this.clock.tick(expectedAge);
-					await endEvent({ event, identifier: identifier1 });
+				sinon.stub(AgeEvent, 'find').rejects(expectedError);
+				const errorLoggerSpy = sinon.spy(errorLogger, 'logUnexpectedError');
 
-					await startEvent({ event, identifier: identifier2 });
-					this.clock.tick(expectedAge / 2);
-					await endEvent({ event, identifier: identifier2 });
-					const events = await orderedEvents({ limit });
+				await orderedEvents({ event, operation: 'max' });
 
-					expect(events.length).to.equal(limit);
-					expect(events[0].age).to.equal(expectedAge);
-					expect(events[0].identifier).to.equal(identifier1);
-				});
-			});
-
-			describe('with no events', () => {
-				it('returns undefined', async () => {
-					const events = await orderedEvents();
-					expect(events).to.be.undefined;
-				});
-			});
-
-			describe('with unexpected error', () => {
-				it('logs the error', async () => {
-					const { event } = ageEventFixture;
-
-					const expectedError = new Error('Something went wrong');
-
-					sinon.stub(AgeEvent, 'find').rejects(expectedError);
-					const errorLoggerSpy = sinon.spy(errorLogger, 'logUnexpectedError');
-
-					await orderedEvents({ event, operation: 'max' });
-
-					expect(errorLoggerSpy.calledOnce).to.be.true;
-				});
+				expect(errorLoggerSpy.calledOnce).to.be.true;
 			});
 		});
 	});

--- a/test/lib/utils/db.test.js
+++ b/test/lib/utils/db.test.js
@@ -16,12 +16,6 @@ describe('DB', () => {
 		});
 	});
 
-	describe('.isDbReady', () => {
-		it('returns the state of the connection', () => {
-			expect(db.isDbReady()).to.equal(db.dbInstance.connection.readyState);
-		});
-	});
-
 	describe('.connect', () => {
 		describe('without an existing connection', () => {
 			it('creates a new connection with expected options', async () => {
@@ -35,7 +29,9 @@ describe('DB', () => {
 						useCreateIndex: true,
 						autoReconnect: true,
 						reconnectInterval: 1000,
-						reconnectTries: 100
+						reconnectTries: 100,
+						bufferCommands: false,
+						bufferMaxEntries: 0
 					}
 				];
 

--- a/test/lib/utils/error-logger.test.js
+++ b/test/lib/utils/error-logger.test.js
@@ -17,14 +17,4 @@ describe('Utils > Error Logger', () => {
 			expect(loggerSpy.calledWith(`Unexpected error occurred: '${err.message}'`)).to.be.true;
 		});
 	});
-
-	describe('.logDbNotReadyError', () => {
-		it('logs an error', () => {
-			const loggerSpy = sinon.spy(logger, 'warn');
-
-			errorLogger.logDbNotReadyError();
-
-			expect(loggerSpy.calledWith('Stethoscope DB not ready.  Please check connection')).to.be.true;
-		});
-	});
 });


### PR DESCRIPTION
I raised an issue with [Mongoose](https://github.com/Automattic/mongoose/issues/7206) regarding the none resolving/rejecting promises when the connection drops, turns out mongoose does offer the ability to avoid buffering commands (which avoids a promise never resolving/rejecting).  Also related: [this issue](https://github.com/Automattic/mongoose/issues/5604)

Disabling `bufferCommands` and `bufferMaxEntries` options allow us to remove the [custom connection check logic](https://github.com/Financial-Times/email-stethoscope/compare/dont-buffer-commands?expand=1#diff-cd6522907f508b01d1cf4a691d4e18b9L7)

[Mongoose's docs suckkkkkkkkk](https://mongoosejs.com/docs/guide.html#bufferCommands) 🤢 