### PR TITLE
Add heroku build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,5 +42,6 @@
   "dependencies": {
     "@financial-times/n-logger": "^5.7.2",
     "mongoose": "^5.3.4"
-  }
+  },
+  "heroku-run-build-script": true
 }


### PR DESCRIPTION
Add `heroku-run-build-script: true` to all repos as part of new security requirements. If you have `heroku-postbuild` command then that will need to go on to your `build` script.